### PR TITLE
Add `files` to `package.json`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,10 @@
     "ajv",
     "keywords"
   ],
+  "files": [
+    "index.js",
+    "keywords"
+  ],
   "author": "Evgeny Poberezkin",
   "license": "MIT",
   "bugs": {


### PR DESCRIPTION
Prevents tests and dotfiles from being published to NPM.  Shaves ~17 KB off the package size, almost halving it.