### PR TITLE
validateSync, validateAsync, valueSync, valueAsync keywords

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,5 +1,6 @@
 env:
   node: true
+  mocha: true
 extends: 'eslint:recommended'
 globals:
   Promise: false

--- a/keywords/index.js
+++ b/keywords/index.js
@@ -15,5 +15,9 @@ module.exports = {
   patternRequired: require('./patternRequired'),
   'switch': require('./switch'),
   select: require('./select'),
-  transform: require('./transform')
+  transform: require('./transform'),
+  validateAsync: require('./validateAsync'),
+  validateSync: require('./validateSync'),
+  valueAsync: require('./valueAsync'),
+  valueSync: require('./valueSync')
 };

--- a/keywords/validateAsync.js
+++ b/keywords/validateAsync.js
@@ -1,0 +1,9 @@
+'use strict';
+
+module.exports = function defFunc (ajv){
+  ajv.addKeyword('validateAsync', {
+    async: true,
+    validate: (fn, data) => fn(data),
+  });
+  return ajv;
+};

--- a/keywords/validateSync.js
+++ b/keywords/validateSync.js
@@ -1,0 +1,8 @@
+'use strict';
+
+module.exports = function defFunc (ajv){
+  ajv.addKeyword('validateSync', {
+    validate: (fn, data) => fn(data),
+  });
+  return ajv;
+};

--- a/keywords/valueAsync.js
+++ b/keywords/valueAsync.js
@@ -1,0 +1,10 @@
+'use strict';
+
+module.exports = function defFunc (ajv){
+  ajv.addKeyword('valueAsync', {
+    modifying: true,
+    valid: true,
+    compile: fn => fn,
+  });
+  return ajv;
+};

--- a/keywords/valueSync.js
+++ b/keywords/valueSync.js
@@ -1,0 +1,10 @@
+'use strict';
+
+module.exports = function defFunc (ajv){
+  ajv.addKeyword('valueSync', {
+    modifying: true,
+    valid: true,
+    compile: fn => fn,
+  });
+  return ajv;
+};

--- a/spec/validateAsync.spec.js
+++ b/spec/validateAsync.spec.js
@@ -1,0 +1,43 @@
+'use strict';
+
+var Ajv = require('ajv');
+var defFunc = require('../keywords/validateAsync');
+var defineKeywords = require('..');
+var should = require('chai').should();
+
+describe('keywords "validateAsync"', function() {
+  var ajvs = [
+    defFunc(getAjv()),
+    defineKeywords(getAjv(), 'validateAsync')
+  ];
+
+  ajvs.forEach(function (ajv, i) {
+    it('should use validateAsync function #' + i, function() {
+
+      var schema = {
+        $async: true,
+        type: 'number',
+        validateAsync: function (data) {
+          return Promise.resolve(data === 1);
+        }
+      };
+
+      var validData = 1;
+
+      var inValidData = 2;
+
+      return Promise.all([
+        ajv.validate(schema, validData).then(validData=>{
+          validData.should.equal(1);
+        }),
+        ajv.validate(schema, inValidData).catch(err=>{
+          err.errors[0].keyword.should.equal('validateAsync');
+        })
+      ]);
+    });
+  });
+
+  function getAjv(format) {
+    return new Ajv({ allErrors: true });
+  }
+});

--- a/spec/validateSync.spec.js
+++ b/spec/validateSync.spec.js
@@ -1,0 +1,36 @@
+'use strict';
+
+var Ajv = require('ajv');
+var defFunc = require('../keywords/validateSync');
+var defineKeywords = require('..');
+var should = require('chai').should();
+
+describe('keywords "validateSync"', function() {
+  var ajvs = [
+    defFunc(getAjv()),
+    defineKeywords(getAjv(), 'validateSync')
+  ];
+
+  ajvs.forEach(function (ajv, i) {
+    it('should use validateSync function #' + i, function() {
+
+      var schema = {
+        type: 'number',
+        validateSync: function (data) {
+          return data === 1;
+        }
+      };
+
+      var validData = 1;
+
+      var inValidData = 2;
+
+      ajv.validate(schema, validData).should.equal(true);
+      ajv.validate(schema, inValidData).should.equal(false);
+    });
+  });
+
+  function getAjv(format) {
+    return new Ajv({ allErrors: true });
+  }
+});

--- a/spec/valueAsync.spec.js
+++ b/spec/valueAsync.spec.js
@@ -1,0 +1,102 @@
+'use strict';
+
+var Ajv = require('ajv');
+var defFunc = require('../keywords/valueAsync');
+var defineKeywords = require('..');
+var should = require('chai').should();
+
+describe('keywords "valueAsync"', function() {
+  var ajvs = [
+    defFunc(getAjv()),
+    defineKeywords(getAjv(), 'valueAsync')
+  ];
+
+  ajvs.forEach(function (ajv, i) {
+    it('should use valueAsync if field is available function #' + i, function() {
+
+      var schema = {
+        $async: true,
+        type: 'object',
+        properties: {
+          id: {
+            type: 'number',
+            valueAsync: function (data, currentPath, parentData, propName, root) {
+              Promise.resolve().then(()=>{
+                parentData[propName] = 3;
+              });
+            }
+          }
+        }
+      };
+
+      var filledData = {id: 1};
+
+      return Promise.all([
+        ajv.validate(schema, filledData)
+        .then(manipulatedData=>{
+          manipulatedData.should.have.property('id').equal(3);
+        }),
+      ]);
+    });
+
+    it('shouldn\'t use valueAsync if field is missing and no default function #' + i, function() {
+
+      var schema = {
+        $async: true,
+        type: 'object',
+        properties: {
+          id: {
+            type: 'number',
+            valueAsync: function (data, currentPath, parentData, propName, root) {
+              Promise.resolve().then(()=>{
+                parentData[propName] = 3;
+              });
+            }
+          }
+        }
+      };
+
+      var emptyData = {};
+
+      return Promise.all([
+        ajv.validate(schema, emptyData)
+        .then(manipulatedData=>{
+          manipulatedData.should.not.have.property('id');
+        }),
+      ]);
+    });
+
+
+    it('should use valueAsync if default keyword is available function #' + i, function() {
+
+      var schema = {
+        $async: true,
+        type: 'object',
+        properties: {
+          id: {
+            type: 'number',
+            default: 4,
+            valueAsync: function (data, currentPath, parentData, propName, root) {
+              Promise.resolve().then(()=>{
+                parentData[propName] = 3;
+              });
+            }
+          }
+        }
+      };
+
+      var emptyData = {};
+
+      return Promise.all([
+        ajv.validate(schema, emptyData)
+            .then(manipulatedData=>{
+              manipulatedData.should.have.property('id').equal(3);
+            }),
+      ]);
+    });
+  });
+
+  function getAjv(format) {
+    return new Ajv({ allErrors: true, useDefaults: true });
+  }
+});

--- a/spec/valueSync.spec.js
+++ b/spec/valueSync.spec.js
@@ -1,0 +1,81 @@
+'use strict';
+
+var Ajv = require('ajv');
+var defFunc = require('../keywords/valueSync');
+var defineKeywords = require('..');
+var should = require('chai').should();
+
+describe('keywords "valueSync"', function() {
+  var ajvs = [
+    defFunc(getAjv()),
+    defineKeywords(getAjv(), 'valueSync')
+  ];
+
+  ajvs.forEach(function (ajv, i) {
+    it('should use valueSync if field is available function #' + i, function() {
+
+      var schema = {
+        type: 'object',
+        properties: {
+          id: {
+            type: 'number',
+            valueSync: function (data, currentPath, parentData, propName, root) {
+              parentData[propName] = 3;
+            }
+          }
+        }
+      };
+
+      var filledData = {id: 1};
+
+      ajv.validate(schema, filledData);
+      filledData.should.have.property('id').equal(3);
+    });
+
+    it('shouldn\'t use valueSync if field is missing and no default function #' + i, function() {
+
+      var schema = {
+        type: 'object',
+        properties: {
+          id: {
+            type: 'number',
+            valueSync: function (data, currentPath, parentData, propName, root) {
+              parentData[propName] = 3;
+            }
+          }
+        }
+      };
+
+      var emptyData = {};
+
+      ajv.validate(schema, emptyData);
+      emptyData.should.not.have.property('id');
+    });
+
+
+    it('should use valueSync if default keyword is available function #' + i, function() {
+
+      var schema = {
+        type: 'object',
+        properties: {
+          id: {
+            type: 'number',
+            default: 4,
+            valueSync: function (data, currentPath, parentData, propName, root) {
+              parentData[propName] = 3;
+            }
+          }
+        }
+      };
+
+      var emptyData = {};
+
+      ajv.validate(schema, emptyData);
+      emptyData.should.have.property('id').equal(3);
+    });
+  });
+
+  function getAjv(format) {
+    return new Ajv({ allErrors: true, useDefaults: true });
+  }
+});


### PR DESCRIPTION
syntactic sugar to facilitate usage of ajv [a/synchronous validation](https://github.com/epoberezkin/ajv#asynchronous-validation) and [overriding values](https://github.com/epoberezkin/ajv/blob/master/CUSTOM.md#define-keyword-with-compilation-function)
___validateSync___ => receive function and use it for validation
___validateAsync___ => async variant of validateSync, requires schema to be async.
___valueSync___ => receive function in which we can override the value provided in data
___valueAsync___ => async variant of valueSync, requires schema to be async.