### PR TITLE
feat: oneRequired keyword

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Custom JSON-Schema keywords for [Ajv](https://github.com/epoberezkin/ajv) valida
   - [Keywords for objects](#keywords-for-objects)
     - [allRequired](allrequired)
     - [anyRequired](anyrequired)
+    - [oneRequired](#onerequired)
     - [patternRequired](#patternrequired)
     - [prohibited](#prohibited)
     - [deepProperties](#deepproperties)
@@ -358,7 +359,24 @@ var alsoValidData = { foo: 1, bar: 2 };
 var invalidDataList = [ {}, { baz: 3 } ];
 ```
 
-__Please note__: By combining `anyRequired` with `maxProperties: 1` you can achieve that exactly one property from the list is required to be present for the data object to pass validation.
+
+#### `oneRequired`
+
+This keyword allows to require the presence of only one property from the list.
+
+This keyword applies only to objects. If the data is not an object, the validation succeeds.
+
+The value of this keyword must be an array of strings, each string being a property name. For data object to be valid exactly one of the properties in this array should be present in the object.
+
+```javascript
+var schema = {
+  oneRequired: ['foo', 'bar']
+};
+
+var validData = { foo: 1 };
+var alsoValidData = { bar: 2, baz: 3 };
+
+var invalidDataList = [ {}, { baz: 3 }, { foo: 1, bar: 2 } ];
 
 
 #### `patternRequired`

--- a/keywords/index.js
+++ b/keywords/index.js
@@ -8,6 +8,7 @@ module.exports = {
   dynamicDefaults: require('./dynamicDefaults'),
   allRequired: require('./allRequired'),
   anyRequired: require('./anyRequired'),
+  oneRequired: require('./oneRequired'),
   prohibited: require('./prohibited'),
   uniqueItemProperties: require('./uniqueItemProperties'),
   deepProperties: require('./deepProperties'),

--- a/keywords/oneRequired.js
+++ b/keywords/oneRequired.js
@@ -1,0 +1,24 @@
+'use strict';
+
+module.exports = function defFunc(ajv) {
+  defFunc.definition = {
+    type: 'object',
+    macro: function (schema) {
+      if (schema.length == 0) return true;
+      if (schema.length == 1) return {required: schema};
+      var schemas = schema.map(function (prop) {
+        return {required: [prop]};
+      });
+      return {oneOf: schemas};
+    },
+    metaSchema: {
+      type: 'array',
+      items: {
+        type: 'string'
+      }
+    }
+  };
+
+  ajv.addKeyword('oneRequired', defFunc.definition);
+  return ajv;
+};

--- a/spec/schema-tests.spec.js
+++ b/spec/schema-tests.spec.js
@@ -8,6 +8,7 @@ var ajvs = [
   defineKeywords(getAjv(), [
     'allRequired',
     'anyRequired',
+    'oneRequired',
     'deepProperties',
     'deepRequired',
     'formatMaximum',

--- a/spec/tests/oneRequired.json
+++ b/spec/tests/oneRequired.json
@@ -1,0 +1,81 @@
+[
+  {
+    "description": "oneRequired requires that at least on property in the list is present",
+    "schema": {
+      "oneRequired": ["foo"]
+    },
+    "tests": [
+      {
+        "description": "property present is valid",
+        "data": {"foo": 1},
+        "valid": true
+      },
+      {
+        "description": "property present with an additional property is valid",
+        "data": {"foo": 1, "baz": 3},
+        "valid": true
+      },
+      {
+        "description": "no property present is invalid",
+        "data": { "baz": 1 },
+        "valid": false
+      },
+      {
+        "description": "empty object is invalid",
+        "data": {},
+        "valid": false
+      }
+    ]
+  },
+  {
+    "description": "multiple properties in prohibited",
+    "schema": {
+      "oneRequired": ["foo", "bar"]
+    },
+    "tests": [
+      {
+        "description": "property present is valid",
+        "data": {"foo": 1},
+        "valid": true
+      },
+      {
+        "description": "property present with an additional property is valid",
+        "data": {"foo": 1, "baz": 3},
+        "valid": true
+      },
+      {
+        "description": "multiple properties present is invalid",
+        "data": {"foo": 1, "bar": 2},
+        "valid": false
+      },
+      {
+        "description": "no property present is invalid",
+        "data": {"baz": 3},
+        "valid": false
+      },
+      {
+        "description": "empty object is invalid",
+        "data": {},
+        "valid": false
+      }
+    ]
+  },
+  {
+    "description": "oneRequired: [] is always valid",
+    "schema": {
+      "oneRequired": []
+    },
+    "tests": [
+      {
+        "description": "any object is valid",
+        "data": {"foo": 1},
+        "valid": true
+      },
+      {
+        "description": "empty object is valid",
+        "data": {},
+        "valid": true
+      }
+    ]
+  }
+]


### PR DESCRIPTION
It is said that you can achieve requiring exactly one property from the list by using `anyRequired` with `maxProperties: 1`, but this approach does not allow any additional properties (which are not in the list) to be present too.

So you can't reproduce this example with `anyRequired`+`maxProperties` combo:
```js
var schema = {
  oneRequired: ['foo', 'bar']
};

var alsoValidData = { bar: 2, baz: 3 };
```