### PR TITLE
Cannot use non-data references with formats

### DIFF
--- a/keywords/dot/_formatLimit.jst
+++ b/keywords/dot/_formatLimit.jst
@@ -33,7 +33,7 @@ var {{=$valid}} = undefined;
 
 {{
   var $schemaFormat = it.schema.format
-    , $isDataFormat = it.opts.$data && $schemaFormat.$data
+    , $isDataFormat = it.opts.$data && typeof $schemaFormat === "object" && $schemaFormat.$data
     , $closingBraces = '';
 }}
 


### PR DESCRIPTION
When using ajv with the { ..., $data: true } option, the "format" schema is treated as an object during the check to see if the schema is a data reference. This leads to errors whenever the schema is not a data reference.