### PR TITLE
Add ability to override or add new `transform`'s transformations

### DIFF
--- a/src/definitions/_types.ts
+++ b/src/definitions/_types.ts
@@ -1,7 +1,39 @@
 import type {KeywordDefinition} from "ajv"
+import type {Transformation} from "./transform"
 
 export interface DefinitionOptions {
   defaultMeta?: string | boolean
 }
+
+export interface KeywordOptions {
+  /**
+   * Modifications to the "transform" keyword
+   */
+  transform?: {
+    /**
+     * Override existing transformations or add additional (new)
+     * @example // overrides existing "trim" transformation, if "trim" didn't exist, it would have been added
+     *   import { trim } from "@example-org/pkgName/example-trim"
+     *
+     *   customTransformations: {
+     *     trim: {
+     *       transformation: trim,
+     *       modulePath: "@example-org/pkgName/example-trim",
+     *     }
+     *   }
+     *
+     *   // module "example.trim.ts" ("@example-org/pkgName/example-trim") exports a function "trim"
+     *   export const trim = (value: string) => value.trim()
+     * @end
+     */
+    customTransformations?: {
+      [key: string]: {
+        transformation: Transformation
+        modulePath: string
+      }
+    }
+  }
+}
+export type KeywordsWithCustomization = keyof KeywordOptions
 
 export type GetDefinition<T extends KeywordDefinition> = (opts?: DefinitionOptions) => T

--- a/src/definitions/_types.ts
+++ b/src/definitions/_types.ts
@@ -1,10 +1,6 @@
 import type {KeywordDefinition} from "ajv"
 import type {Transformation} from "./transform"
 
-export interface DefinitionOptions {
-  defaultMeta?: string | boolean
-}
-
 export interface KeywordOptions {
   /**
    * Modifications to the "transform" keyword
@@ -15,7 +11,7 @@ export interface KeywordOptions {
      * @example // overrides existing "trim" transformation, if "trim" didn't exist, it would have been added
      *   import { trim } from "@example-org/pkgName/example-trim"
      *
-     *   customTransformations: {
+     *   transform: {
      *     trim: {
      *       transformation: trim,
      *       modulePath: "@example-org/pkgName/example-trim",
@@ -26,14 +22,16 @@ export interface KeywordOptions {
      *   export const trim = (value: string) => value.trim()
      * @end
      */
-    customTransformations?: {
-      [key: string]: {
-        transformation: Transformation
-        modulePath: string
-      }
+    [key: string]: {
+      transformation: Transformation
+      modulePath: string
     }
   }
 }
 export type KeywordsWithCustomization = keyof KeywordOptions
+
+export interface DefinitionOptions extends KeywordOptions {
+  defaultMeta?: string | boolean
+}
 
 export type GetDefinition<T extends KeywordDefinition> = (opts?: DefinitionOptions) => T

--- a/src/definitions/transform.ts
+++ b/src/definitions/transform.ts
@@ -1,5 +1,5 @@
 import type {CodeKeywordDefinition, AnySchemaObject, KeywordCxt, Code, Name} from "ajv"
-import type {KeywordOptions} from "./_types"
+import type {DefinitionOptions} from "./_types"
 import {_, stringify, getProperty} from "ajv/dist/compile/codegen"
 
 type TransformationName =
@@ -29,8 +29,8 @@ const builtInTransformations: {[key in TransformationName]: Transformation} = {
   toEnumCase: (s, cfg) => cfg?.hash[configKey(s)] || s,
 }
 
-function getDef(opts?: KeywordOptions["transform"]): CodeKeywordDefinition {
-  const customTransformations = opts?.customTransformations || {}
+function getDef(opts?: DefinitionOptions): CodeKeywordDefinition {
+  const customTransformations = opts?.transform || {}
   const availableTransformations = [
     ...Object.keys(builtInTransformations),
     ...Object.keys(customTransformations),

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,33 +1,46 @@
+/* eslint-disable valid-jsdoc */ // this rule is deprecated and insists on adding type annotations that already exist in TypeScript
 import type Ajv from "ajv"
 import type {Plugin} from "ajv"
-import type {KeywordOptions, KeywordsWithCustomization} from "./definitions/_types"
-import plugins from "./keywords"
+import type {DefinitionOptions} from "./definitions/_types"
+import keywords from "./keywords"
 
 export {AjvKeywordsError} from "./definitions"
 
+/**
+ * @param ajv instance
+ * @param specificKeywords only these keywords to-be-added
+ * @param options modifications passed to keywords
+ * @returns ajv instance
+ */
 const ajvKeywords: Plugin<string | string[]> = (
   ajv: Ajv,
-  keyword?: string | string[],
-  keywordOptions: KeywordOptions = {}
+  specificKeywords?: string | string[],
+  options: DefinitionOptions = {}
 ): Ajv => {
-  if (Array.isArray(keyword)) {
-    for (const k of keyword) get(k)(ajv, keywordOptions[k as KeywordsWithCustomization])
+  if (Array.isArray(specificKeywords)) {
+    for (const k of specificKeywords) addKeyword(ajv, k, options)
     return ajv
   }
-  if (keyword) {
-    get(keyword)(ajv, keywordOptions[keyword as KeywordsWithCustomization])
+  if (specificKeywords) {
+    addKeyword(ajv, specificKeywords, options)
     return ajv
   }
-  for (keyword in plugins) get(keyword)(ajv, keywordOptions[keyword as KeywordsWithCustomization])
+
+  for (const keyword in keywords) addKeyword(ajv, keyword, options)
   return ajv
 }
 
 ajvKeywords.get = get
 
 function get(keyword: string): Plugin<any> {
-  const defFunc = plugins[keyword]
+  const defFunc = keywords[keyword]
   if (!defFunc) throw new Error("Unknown keyword " + keyword)
   return defFunc
+}
+
+function addKeyword(ajv: Ajv, keyword: string, options: DefinitionOptions): void {
+  const defFunc = get(keyword)
+  defFunc(ajv, options)
 }
 
 export default ajvKeywords

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,19 +1,24 @@
 import type Ajv from "ajv"
 import type {Plugin} from "ajv"
+import type {KeywordOptions, KeywordsWithCustomization} from "./definitions/_types"
 import plugins from "./keywords"
 
 export {AjvKeywordsError} from "./definitions"
 
-const ajvKeywords: Plugin<string | string[]> = (ajv: Ajv, keyword?: string | string[]): Ajv => {
+const ajvKeywords: Plugin<string | string[]> = (
+  ajv: Ajv,
+  keyword?: string | string[],
+  keywordOptions: KeywordOptions = {}
+): Ajv => {
   if (Array.isArray(keyword)) {
-    for (const k of keyword) get(k)(ajv)
+    for (const k of keyword) get(k)(ajv, keywordOptions[k as KeywordsWithCustomization])
     return ajv
   }
   if (keyword) {
-    get(keyword)(ajv)
+    get(keyword)(ajv, keywordOptions[keyword as KeywordsWithCustomization])
     return ajv
   }
-  for (keyword in plugins) get(keyword)(ajv)
+  for (keyword in plugins) get(keyword)(ajv, keywordOptions[keyword as KeywordsWithCustomization])
   return ajv
 }
 

--- a/src/keywords/transform.ts
+++ b/src/keywords/transform.ts
@@ -1,7 +1,8 @@
 import type {Plugin} from "ajv"
+import type {KeywordOptions} from "../definitions/_types"
 import getDef from "../definitions/transform"
 
-const transform: Plugin<undefined> = (ajv) => ajv.addKeyword(getDef())
+const transform: Plugin<KeywordOptions["transform"]> = (ajv, opts) => ajv.addKeyword(getDef(opts))
 
 export default transform
 module.exports = transform


### PR DESCRIPTION
Closes #99
And might close #66 , so users-developers customize `transform` in their repos in any way they want.

@epoberezkin Please let me know, if you are okay with this design, and I'll proceed with adding tests.
- on a side note, it'd be great, if the codegen supported `import`, instead of `require`