### PR TITLE
Replace `fast-deep-equal` to `fast-equals`

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "homepage": "https://github.com/epoberezkin/ajv-keywords#readme",
   "dependencies": {
-    "fast-deep-equal": "^3.1.3"
+    "fast-equals": "^5.0.0"
   },
   "peerDependencies": {
     "ajv": "^8.8.2"

--- a/src/definitions/uniqueItemProperties.ts
+++ b/src/definitions/uniqueItemProperties.ts
@@ -1,5 +1,5 @@
 import type {FuncKeywordDefinition, AnySchemaObject} from "ajv"
-import equal = require("fast-deep-equal")
+import {deepEqual} from "fast-equals"
 
 const SCALAR_TYPES = ["number", "integer", "string", "boolean", "null"]
 
@@ -31,7 +31,7 @@ export default function getDef(): FuncKeywordDefinition {
               if (!x || typeof x != "object") continue
               for (let j = i; j--; ) {
                 const y = data[j]
-                if (y && typeof y == "object" && equal(x[key], y[key])) return false
+                if (y && typeof y == "object" && deepEqual(x[key], y[key])) return false
               }
             }
           }


### PR DESCRIPTION
Suggestion to replace `fast-deep-equal` to well-maintained faster implementation.

The same as https://github.com/ajv-validator/ajv/pull/2235